### PR TITLE
Merge pull request #11 from cmagnobarbosa/fix_coverage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,8 @@
 Overview
 ========
 
+|License| |Build| |Coverage| |Quality|
+
 The **of_l2ls** application is used in basic operation of switches. It
 implements the algorithm known as L2 Learning Switch, which aims to figure out
 which host is attached to which switch port. The switch keeps a table that
@@ -41,3 +43,17 @@ number.
 When the host B answers the request, the switch adds to this table an entry
 mapping the mac address of host B to the port in which it is connected. This
 process goes on until the switch learns which port all hosts are connected.
+
+.. TAGs
+
+.. |License| image:: https://img.shields.io/github/license/kytos/kytos.svg
+   :target: https://github.com/kytos/of_l2ls/blob/master/LICENSE
+.. |Build| image:: https://scrutinizer-ci.com/g/kytos/of_l2ls/badges/build.png?b=master
+  :alt: Build status
+  :target: https://scrutinizer-ci.com/g/kytos/of_l2ls/?branch=master
+.. |Coverage| image:: https://scrutinizer-ci.com/g/kytos/of_l2ls/badges/coverage.png?b=master
+  :alt: Code coverage
+  :target: https://scrutinizer-ci.com/g/kytos/of_l2ls/?branch=master
+.. |Quality| image:: https://scrutinizer-ci.com/g/kytos/of_l2ls/badges/quality-score.png?b=master
+  :alt: Code-quality score
+  :target: https://scrutinizer-ci.com/g/kytos/of_l2ls/?branch=master

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,7 +9,7 @@
 -e git+https://github.com/kytos/python-openflow.git#egg=python-openflow
 astroid==2.2.5            # via pylint
 click==7.0                # via pip-tools
-coverage==4.5.3
+coverage==5.0.3
 docopt==0.6.2             # via yala
 filelock==3.0.10          # via tox
 isort==4.3.15             # via pylint, yala

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Module to test the napp kytos/of_l2ls."""


### PR DESCRIPTION
The coverage version was creating an error when running Scrutinizer.
This commit changes coverage version from 4.5.3 to 5.0.3 and add some badges in README.