### PR TITLE
Add `table_id` field and set value to zero

### DIFF
--- a/main.py
+++ b/main.py
@@ -54,6 +54,7 @@ class Main(KytosNApp):
 
         flow = {}
         flow['priority'] = 0
+        flow['table_id'] = settings.TABLE_ID
         flow['actions'] = [{'action_type': 'output',
                             'port': Port13.OFPP_CONTROLLER}]
 
@@ -69,6 +70,7 @@ class Main(KytosNApp):
         flow = {}
         match = {}
         flow['priority'] = settings.FLOW_PRIORITY
+        flow['table_id'] = settings.TABLE_ID
 
         match['dl_src'] = packet.source.value
         match['dl_dst'] = packet.destination.value

--- a/settings.py
+++ b/settings.py
@@ -7,5 +7,5 @@ LLDP_MACS = ['01:80:c2:00:00:0e', '01:80:c2:00:00:03',
 
 # flow_priority = 10
 FLOW_PRIORITY = 10
-
+TABLE_ID = 0
 FLOW_MANAGER_URL = 'http://localhost:8181/api/kytos/flow_manager/v2'

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -34,8 +34,10 @@ class TestMain(TestCase):
         flow_manager_url = 'http://localhost:8181/api/kytos/flow_manager/v2'
 
         mock_settings.FLOW_MANAGER_URL = flow_manager_url
+        mock_settings.TABLE_ID = 0
         expected_flow = {}
         expected_flow['priority'] = 0
+        expected_flow['table_id'] = 0
         expected_flow['actions'] = [{'action_type': 'output',
                                      'port': 123}]
 
@@ -61,6 +63,7 @@ class TestMain(TestCase):
         match = {}
 
         expected_flow['priority'] = 10
+        expected_flow['table_id'] = 0
 
         match['dl_src'] = '00:00:00:00:00:00:00:01'
         match['dl_dst'] = '00:00:00:00:00:00:00:02'
@@ -70,6 +73,7 @@ class TestMain(TestCase):
         expected_flow['actions'] = [{'action_type': 'output',
                                      'port': 123}]
         mock_settings.FLOW_PRIORITY = 10
+        mock_settings.TABLE_ID = 0
 
         packet = MagicMock()
         packet.source.value = '00:00:00:00:00:00:00:01'


### PR DESCRIPTION
### :octocat: Are you working on some issue? Identify the issue!

Fix #26 


### :bookmark_tabs: Description of the Change

Create a ``table_id`` field and set the default value to 0 and update tests to support it. 
The ``table_id`` field is necessary for the consistency check performed by ``kytos/flow_manager``.

### :computer: Verification Process

- Manually checked and performed the unit tests without any error.

### :page_facing_up: Release Notes

- Add ``table_id`` field required by consistency check in flows.
